### PR TITLE
feat: Add support for `getJokes` function

### DIFF
--- a/api/jokes.js
+++ b/api/jokes.js
@@ -1,0 +1,5 @@
+const jokeData = require('./jokes.json');
+
+export function getJokes(jokeIdx) {
+  return jokeData[jokeIdx];
+}

--- a/api/jokes.json
+++ b/api/jokes.json
@@ -1,0 +1,122 @@
+[
+  {
+    "setup": "Why did the chicken cross the playground?",
+    "punchline": "To get to the other slide."
+  },
+  {
+    "setup": "What do you call a belt made of watches?",
+    "punchline": "A waist of time."
+  },
+  {
+    "setup": "Why did the dog cross the road?",
+    "punchline": "To get to the barking lot."
+  },
+  {
+    "setup": "Why did the man fall down the well?",
+    "punchline": "Because he didn't see that well."
+  },
+  {
+    "setup": "What did the buffalo say to his son when he left for work?",
+    "punchline": "Bison."
+  },
+  {
+    "setup": "What did the ocean say to the beach?",
+    "punchline": "Nothing, it just waved."
+  },
+  {
+    "setup": "Who shaves at least 20 times a day?",
+    "punchline": "A barber."
+  },
+  {
+    "setup": "What do you call a joke that isn't funny?",
+    "punchline": "A sentence."
+  },
+  {
+    "setup": "What did the house wear to its birthday party?",
+    "punchline": "Address."
+  },
+  {
+    "setup": "What did the man say when he lost his truck?",
+    "punchline": "Where's my truck?"
+  },
+  {
+    "setup": "What's blue and smells like red paint?",
+    "punchline": "Blue paint."
+  },
+  {
+    "setup": "Why did the mailman die?",
+    "punchline": "Because everyone dies."
+  },
+  {
+    "setup": "How many apples grow on a tree?",
+    "punchline": "All of them."
+  },
+  {
+    "setup": "What's something that makes everyone smile?",
+    "punchline": "Face muscles."
+  },
+  {
+    "setup": "What do you call 100 lawyers at the bottom of the ocean?",
+    "punchline": "A horrible boating accident."
+  },
+  {
+    "setup": "What is Forrest Gump's e-mail password?",
+    "punchline": "1forrest1."
+  },
+  {
+    "setup": "Why was the broom late to class?",
+    "punchline": "Because it over-swept."
+  },
+  {
+    "setup": "If April showers bring May flowers, what do May flowers bring?",
+    "punchline": "Pilgrims."
+  },
+  {
+    "setup": "Why shouldn't you buy Velcro?",
+    "punchline": "Because it's a rip off."
+  },
+  {
+    "setup": "Why did the picture go to jail?",
+    "punchline": "Because it was framed."
+  },
+  {
+    "setup": "How do you make holy water?",
+    "punchline": "You boil the hell out of it."
+  },
+  {
+    "setup": "Why do some couples to to the gym together?",
+    "punchline": "Because they want their relationship to work out."
+  },
+  {
+    "setup": "Why can't a leopard hide?",
+    "punchline": "Because it's always spotted."
+  },
+  {
+    "setup": "How do you track Will Smith in the snow?",
+    "punchline": "You follow the fresh prints."
+  },
+  {
+    "setup": "How many ants does it take to fill an apartment?",
+    "punchline": "Tenants."
+  },
+  {
+    "setup": "What do you call a boomerang that doesn't come back?",
+    "punchline": "A stick."
+  },
+  {
+    "setup": "What did Yoda say when he saw himself in 1080p resolution?",
+    "punchline": "HDMI."
+  },
+  {
+    "setup": "Why does a duck have feathers?",
+    "punchline": "To cover its butt quack."
+  },
+  {
+    "setup": "What do you call a dinosaur that takes care of its teeth?",
+    "punchline": "A flossiraptor."
+  },
+  {
+    "setup": "What do you call a priest that becomes a lawyer?",
+    "punchline": "A father-in-law."
+  }
+]

--- a/api/jokes.spec.js
+++ b/api/jokes.spec.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-undef */
+import { getJokes } from './jokes';
+
+describe('getJokes', () => {
+  it('returns joke at index 12 when passing in 12 as argument', () => {
+    const joke = getJokes(12);
+    expect(joke.setup).toBe('How many apples grow on a tree?');
+  });
+});


### PR DESCRIPTION
## Description
- Add jokes.json under /api
  - Contains array of joke objects with `setup` and `punchline` attributes
- Add jokes.js under /api
  - Exports getJokes function that accepts parameter jokeIdx and returns the joke from jokes.json at that index
- Add tests for jokes.js

## Spec
See Issue: [FSA22V1-72](https://sparkbox.atlassian.net/browse/FSA22V1-72)

## Validation
- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate
1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Install all dependencies with `npm i`.
4. Start the program with `npm run dev`.
5. Run tests with `npm run test`.
6. Verify SFW-ness of jokes in api/jokes.json.
