### PR TITLE
feat--joke-endpoint-22V1-70

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "prettier.jsxSingleQuote": true,
+  "prettier.singleQuote": true
+}

--- a/api/routes.js
+++ b/api/routes.js
@@ -1,37 +1,32 @@
-const Hapi = require("@hapi/hapi");
+/* eslint-disable quotes */
+const Hapi = require('@hapi/hapi');
 
 const init = async () => {
   const server = Hapi.server({
     port: 8081,
-    host: "localhost",
+    host: 'localhost',
   });
 
   server.route({
-    method: "GET",
-    path: "/",
-    handler: () => "Home",
+    method: 'GET',
+    path: '/welcome',
+    handler: () => 'Hello World!',
   });
 
   server.route({
-    method: "GET",
-    path: "/welcome",
-    handler: () => "Hello World!",
-  });
-
-  server.route({
-    method: "GET",
-    path: "/jokes",
+    method: 'GET',
+    path: '/jokes',
     handler: () => ({
-      setup: "Joke setup",
-      punchline: "Joke punchline",
+      setup: 'Joke setup',
+      punchline: 'Joke punchline',
     }),
   });
 
   await server.start();
-  console.log("Server running on %s", server.info.uri);
+  console.log('Server running on %s', server.info.uri);
 };
 
-process.on("unhandledRejection", (err) => {
+process.on('unhandledRejection', (err) => {
   console.log(err);
   process.exit(1);
 });

--- a/api/routes.js
+++ b/api/routes.js
@@ -1,28 +1,37 @@
-const Hapi = require('@hapi/hapi');
+const Hapi = require("@hapi/hapi");
 
 const init = async () => {
   const server = Hapi.server({
     port: 8081,
-    host: 'localhost',
+    host: "localhost",
   });
 
   server.route({
-    method: 'GET',
-    path: '/',
-    handler: () => 'Home',
+    method: "GET",
+    path: "/",
+    handler: () => "Home",
   });
 
   server.route({
-    method: 'GET',
-    path: '/welcome',
-    handler: () => 'Hello World!',
+    method: "GET",
+    path: "/welcome",
+    handler: () => "Hello World!",
+  });
+
+  server.route({
+    method: "GET",
+    path: "/jokes",
+    handler: () => ({
+      setup: "Joke setup",
+      punchline: "Joke punchline",
+    }),
   });
 
   await server.start();
-  console.log('Server running on %s', server.info.uri);
+  console.log("Server running on %s", server.info.uri);
 };
 
-process.on('unhandledRejection', (err) => {
+process.on("unhandledRejection", (err) => {
   console.log(err);
   process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   },
   "dependencies": {
     "@hapi/hapi": "^20.2.1"
+  },
+  "prettier": {
+    "singleQuote": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
   },
   "dependencies": {
     "@hapi/hapi": "^20.2.1"
-  },
-  "prettier": {
-    "singleQuote": true
   }
 }


### PR DESCRIPTION
## Description
Set up 'joke' endpoint

## Spec

Includes:
-Update to routes.js with new /jokes GET route
-/jokes route returns a single hardcoded joke, as an object

## Validation

- [ ] This PR has code changes, and our linters still pass.

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Run `npm run api` on your CLI
4. Navigate to localhost:8081/joke to see the joke object render in the browser 
