### PR TITLE
feat--joke-endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "prettier": {
+    "singleQuote": true
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "prettier": {
-    "singleQuote": true
-  }
-}

--- a/api/routes.js
+++ b/api/routes.js
@@ -1,31 +1,31 @@
-const Hapi = require('@hapi/hapi');
+const Hapi = require("@hapi/hapi");
 
 const init = async () => {
   const server = Hapi.server({
     port: 8081,
-    host: 'localhost',
+    host: "localhost",
   });
 
   server.route({
-    method: 'GET',
-    path: '/welcome',
-    handler: () => 'Hello World!!',
+    method: "GET",
+    path: "/welcome",
+    handler: () => "Hello World!!",
   });
 
   server.route({
-    method: 'GET',
-    path: '/jokes',
+    method: "GET",
+    path: "/jokes",
     handler: () => ({
-      setup: 'Joke setup',
-      punchline: 'Joke punchline',
+      setup: "Joke setup",
+      punchline: "Joke punchline",
     }),
   });
 
   await server.start();
-  console.log('Server running on %s', server.info.uri);
+  console.log("Server running on %s", server.info.uri);
 };
 
-process.on('unhandledRejection', (err) => {
+process.on("unhandledRejection", (err) => {
   console.log(err);
   process.exit(1);
 });

--- a/api/routes.js
+++ b/api/routes.js
@@ -9,7 +9,7 @@ const init = async () => {
   server.route({
     method: 'GET',
     path: '/welcome',
-    handler: () => 'Hello World!!',
+    handler: () => 'Hello World!',
   });
 
   server.route({

--- a/api/routes.js
+++ b/api/routes.js
@@ -1,28 +1,32 @@
-const Hapi = require('@hapi/hapi');
+/* eslint-disable quotes */
+const Hapi = require("@hapi/hapi");
 
 const init = async () => {
   const server = Hapi.server({
     port: 8081,
-    host: 'localhost',
+    host: "localhost",
   });
 
   server.route({
-    method: 'GET',
-    path: '/',
-    handler: () => 'Home',
+    method: "GET",
+    path: "/welcome",
+    handler: () => "Hello World!",
   });
 
   server.route({
-    method: 'GET',
-    path: '/welcome',
-    handler: () => 'Hello World!',
+    method: "GET",
+    path: "/jokes",
+    handler: () => ({
+      setup: "Joke setup",
+      punchline: "Joke punchline",
+    }),
   });
 
   await server.start();
-  console.log('Server running on %s', server.info.uri);
+  console.log("Server running on %s", server.info.uri);
 };
 
-process.on('unhandledRejection', (err) => {
+process.on("unhandledRejection", (err) => {
   console.log(err);
   process.exit(1);
 });

--- a/api/routes.js
+++ b/api/routes.js
@@ -9,7 +9,7 @@ const init = async () => {
   server.route({
     method: "GET",
     path: "/welcome",
-    handler: () => "Hello World!!",
+    handler: () => "Hello World!",
   });
 
   server.route({

--- a/api/routes.js
+++ b/api/routes.js
@@ -1,32 +1,31 @@
-/* eslint-disable quotes */
-const Hapi = require("@hapi/hapi");
+const Hapi = require('@hapi/hapi');
 
 const init = async () => {
   const server = Hapi.server({
     port: 8081,
-    host: "localhost",
+    host: 'localhost',
   });
 
   server.route({
-    method: "GET",
-    path: "/welcome",
-    handler: () => "Hello World!",
+    method: 'GET',
+    path: '/welcome',
+    handler: () => 'Hello World!',
   });
 
   server.route({
-    method: "GET",
-    path: "/jokes",
+    method: 'GET',
+    path: '/jokes',
     handler: () => ({
-      setup: "Joke setup",
-      punchline: "Joke punchline",
+      setup: 'Joke setup',
+      punchline: 'Joke punchline',
     }),
   });
 
   await server.start();
-  console.log("Server running on %s", server.info.uri);
+  console.log('Server running on %s', server.info.uri);
 };
 
-process.on("unhandledRejection", (err) => {
+process.on('unhandledRejection', (err) => {
   console.log(err);
   process.exit(1);
 });

--- a/api/routes.js
+++ b/api/routes.js
@@ -1,31 +1,31 @@
-const Hapi = require("@hapi/hapi");
+const Hapi = require('@hapi/hapi');
 
 const init = async () => {
   const server = Hapi.server({
     port: 8081,
-    host: "localhost",
+    host: 'localhost',
   });
 
   server.route({
-    method: "GET",
-    path: "/welcome",
-    handler: () => "Hello World!",
+    method: 'GET',
+    path: '/welcome',
+    handler: () => 'Hello World!',
   });
 
   server.route({
-    method: "GET",
-    path: "/jokes",
+    method: 'GET',
+    path: '/jokes',
     handler: () => ({
-      setup: "Joke setup",
-      punchline: "Joke punchline",
+      setup: 'Joke setup',
+      punchline: 'Joke punchline',
     }),
   });
 
   await server.start();
-  console.log("Server running on %s", server.info.uri);
+  console.log('Server running on %s', server.info.uri);
 };
 
-process.on("unhandledRejection", (err) => {
+process.on('unhandledRejection', (err) => {
   console.log(err);
   process.exit(1);
 });

--- a/api/routes.js
+++ b/api/routes.js
@@ -9,7 +9,7 @@ const init = async () => {
   server.route({
     method: 'GET',
     path: '/welcome',
-    handler: () => 'Hello World!',
+    handler: () => 'Hello World!!',
   });
 
   server.route({


### PR DESCRIPTION
## Description
Setup 'jokes' endpoint

issues:
-fixed prettier config to default to single quotes
-created local global .gitignore, as this was a local problem
-I also removed the /home path as it was something I added that is not needed

added:
-Update to routes.js with new /jokes GET route endpoint
-/jokes route returns a single hardcoded joke, as an object

## Spec

See issue: 22V1-70

## Validation

- [ ] This PR has code changes, and our linters still pass.

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Run `npm run api` on your CLI
4. Navigate to localhost:8081/jokes to see the joke object render in the browser 