### PR TITLE
Adds /jokesUpperBound endpoint

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -2,6 +2,10 @@ import Hapi from '@hapi/hapi';
 
 import getJokes from './jokes';
 
+const upperBound = require('../src/Utilities/upperBound.js');
+
+module.exports = upperBound;
+
 const init = async () => {
   const server = Hapi.server({
     port: 8081,
@@ -33,6 +37,12 @@ const init = async () => {
       error: 'Bad Request',
       message: 'No joke index provided',
     }).code(400),
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/jokesUpperBound',
+    handler: () => upperBound,
   });
 
   await server.start();

--- a/api/routes.js
+++ b/api/routes.js
@@ -2,9 +2,7 @@ import Hapi from '@hapi/hapi';
 
 import getJokes from './jokes';
 
-const upperBound = require('../src/Utilities/upperBound.js');
-
-module.exports = upperBound;
+import getUpperBound from '../src/Utilities/upperBound.js';
 
 const init = async () => {
   const server = Hapi.server({
@@ -42,7 +40,7 @@ const init = async () => {
   server.route({
     method: 'GET',
     path: '/jokesUpperBound',
-    handler: () => upperBound,
+    handler: () => getUpperBound(),
   });
 
   await server.start();

--- a/src/Utilities/index.js
+++ b/src/Utilities/index.js
@@ -1,4 +1,0 @@
-import '../css/index.css';
-import { getUpperBound } from './upperBound.js';
-
-getUpperBound();

--- a/src/Utilities/index.js
+++ b/src/Utilities/index.js
@@ -1,0 +1,4 @@
+import '../css/index.css';
+import { getUpperBound } from './upperBound.js';
+
+getUpperBound();

--- a/src/Utilities/upperBound.js
+++ b/src/Utilities/upperBound.js
@@ -1,0 +1,8 @@
+const jokeData = require('../../api/jokes.json');
+
+function getUpperBound() {
+  console.log(jokeData.length);
+  return jokeData.length;
+}
+
+export { getUpperBound };

--- a/src/Utilities/upperBound.js
+++ b/src/Utilities/upperBound.js
@@ -2,7 +2,7 @@ const jokeData = require('../../api/jokes.json');
 
 function getUpperBound() {
   console.log(jokeData.length);
-  return jokeData.length;
+  return jokeData.length - 1;
 }
 
 module.exports = getUpperBound();

--- a/src/Utilities/upperBound.js
+++ b/src/Utilities/upperBound.js
@@ -1,8 +1,5 @@
-const jokeData = require('../../api/jokes.json');
+import jokeData from '../../api/jokes.json';
 
-function getUpperBound() {
-  console.log(jokeData.length);
-  return jokeData.length - 1;
-}
+const getUpperBound = () => (jokeData.length - 1);
 
-module.exports = getUpperBound();
+export default getUpperBound;

--- a/src/Utilities/upperBound.js
+++ b/src/Utilities/upperBound.js
@@ -5,4 +5,4 @@ function getUpperBound() {
   return jokeData.length;
 }
 
-export { getUpperBound };
+module.exports = getUpperBound();

--- a/src/Utilities/upperBound.spec.js
+++ b/src/Utilities/upperBound.spec.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-undef */
+import { getUpperBound } from './upperBound';
+
+describe('UpperBound', () => {
+  it('returns the count of all the jokes', () => {
+    console.log(getUpperBound());
+    const joke = getUpperBound();
+    expect(joke).toBe(30);
+  });
+});

--- a/src/Utilities/upperBound.spec.js
+++ b/src/Utilities/upperBound.spec.js
@@ -1,5 +1,4 @@
-/* eslint-disable no-undef */
-import { getUpperBound } from './upperBound';
+import getUpperBound from './upperBound';
 
 describe('UpperBound', () => {
   it('returns the count of all the jokes', () => {

--- a/src/Utilities/upperBound.spec.js
+++ b/src/Utilities/upperBound.spec.js
@@ -4,6 +4,6 @@ describe('UpperBound', () => {
   it('returns the count of all the jokes', () => {
     console.log(getUpperBound());
     const joke = getUpperBound();
-    expect(joke).toBe(30);
+    expect(joke).toBe(29);
   });
 });


### PR DESCRIPTION
## Description

Setup `/jokesUpperBound` endpoint

details
-In the newly created Utilities folder (recommended by a dev), we now have upperBound.js and upperBound.spec.js
-Also this log WAS supposed to be separate in it's own file, according to the card
-In upperBound.js, a function was written that determines the number of jokes minus 1
-The corresponding tests live in its spec file
-In routes.js, a GET request was created with the path '/jokesUpperBound'
-This may not have been the most elegant solution, but in the handler function, I used a variable called upperBound, which I defined at the top of the routes page (as where to find the function)

## Spec

See Issue: FSA22V1-76 (https://sparkbox.atlassian.net/browse/FSA22V1-76)

## Validation

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Run `npm run test` in the terminal
4. Verify that all tests pass, especially this newly created upperBound.spec.js
5. Run `npm run api`
6. Navigate to http://localhost:8081/jokesUpperBound
7. Verify that the number 29 renders in the browser. (This is the number of hardcoded jokes, 30, minus one)
