### PR TITLE
feat: Add support for refreshing jokes

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -29,7 +29,7 @@ const init = async () => {
 
   server.route({
     method: 'GET',
-    path: '/jokes/',
+    path: '/jokes/{any*}',
     handler: (request, h) => h.response({
       statusCode: 400,
       error: 'Bad Request',

--- a/src/js/getNextJokeIdx.js
+++ b/src/js/getNextJokeIdx.js
@@ -1,0 +1,7 @@
+export const getNextJokeIdx = (currentJokeIdx, upperBound) => {
+  let nextJokeIdx = currentJokeIdx + 1;
+
+  if (nextJokeIdx > upperBound) nextJokeIdx = 0;
+
+  return nextJokeIdx;
+};

--- a/src/js/getNextJokeIdx.spec.js
+++ b/src/js/getNextJokeIdx.spec.js
@@ -1,0 +1,15 @@
+import { getNextJokeIdx } from './getNextJokeIdx';
+
+describe('getNextJokeIdx', () => {
+  it('incremements the current joke idx by 1', () => {
+    const nextJokeIdx = getNextJokeIdx(2);
+
+    expect(nextJokeIdx).toBe(3);
+  });
+
+  it('resets current joke idx to 0 when upper bound is reached', () => {
+    const nextJokeIdx = getNextJokeIdx(4, 4);
+
+    expect(nextJokeIdx).toBe(0);
+  });
+});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,9 +1,33 @@
 import '../css/index.css';
 import { jokeFetcher } from './jokeFetcher';
 import { renderJoke } from './renderJoke';
+import { getNextJokeIdx } from './getNextJokeIdx';
 
-const main = async () => {
-  const joke = await jokeFetcher();
-  renderJoke(joke);
+const UPPER_BOUND = 4;
+
+const addNextJoke = async (nextJokeIdx) => {
+  const nextJoke = await jokeFetcher(nextJokeIdx);
+
+  renderJoke(nextJoke);
 };
-main();
+
+const bindEventListenerToRefreshButton = (currentJokeIdx) => {
+  const refreshButton = document.getElementById('refresh');
+  let currentJokeState = currentJokeIdx;
+
+  refreshButton.addEventListener('click', async (e) => {
+    e.preventDefault();
+    currentJokeState = getNextJokeIdx(currentJokeState, UPPER_BOUND);
+    addNextJoke(currentJokeState);
+  });
+};
+
+const showCurrentJoke = async () => {
+  const currentJokeIdx = 0;
+  const currentJoke = await jokeFetcher(currentJokeIdx);
+
+  renderJoke(currentJoke);
+  bindEventListenerToRefreshButton(currentJokeIdx);
+};
+
+showCurrentJoke();

--- a/src/js/jokeFetcher.js
+++ b/src/js/jokeFetcher.js
@@ -1,6 +1,6 @@
-export const jokeFetcher = async () => {
+export const jokeFetcher = async (jokeIdx) => {
   try {
-    const result = await fetch('http://localhost:8081/jokes/0');
+    const result = await fetch(`http://localhost:8081/jokes/${jokeIdx}`);
     const joke = await result.json();
     return joke;
   } catch (err) {

--- a/src/js/jokeFetcher.spec.js
+++ b/src/js/jokeFetcher.spec.js
@@ -17,11 +17,17 @@ afterEach(() => {
 
 describe('jokeFetcher', () => {
   it('fetches joke', async () => {
-    const joke = await jokeFetcher();
+    const joke = await jokeFetcher(0);
     expect(joke).toEqual({
       setup: 'Why did the chicken cross the playground?',
       punchline: 'To get to the other slide.',
     });
+  });
+
+  it('makes a call to the correct API endpoint', async () => {
+    await jokeFetcher(3);
+
+    expect(fetch).toHaveBeenCalledWith('http://localhost:8081/jokes/3');
   });
 
   it('returns error message on failure', async () => {


### PR DESCRIPTION
## Description
- `jokeFetcher` function accepts jokeIdx parameter
- Add tests for `getNextJokeIdx` function
- `getNextJokeIdx` function handles logic for cycling retrieving next joke and cycling back to beginning index
- Add support for refreshing jokes
  - Refresh button cycles through the first five jokes in `jokes.json`.

## Spec
See Issue: [FSA22V1-77](https://sparkbox.atlassian.net/browse/FSA22V1-77)

## Validation
- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate
1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Install all dependencies with `npm i`.
4. Start the API server with `npm run api`.
5. Start the application with `npm run dev`.
6. Verify refresh button cycles through five jokes before starting back at the beginning.
7. Verify all tests pass.
