### PR TITLE
Feat  fetch upperbound

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -40,6 +40,11 @@ const init = async () => {
   server.route({
     method: 'GET',
     path: '/jokesUpperBound',
+    options: {
+      cors: {
+        origin: ['*'], // array of allowed origins
+      },
+    },
     handler: () => getUpperBound(),
   });
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,9 +1,7 @@
 import '../css/index.css';
-import { jokeFetcher } from './jokeFetcher';
+import { jokeFetcher, jokeFetcherUpperBounds } from './jokeFetcher';
 import { renderJoke } from './renderJoke';
 import { getNextJokeIdx } from './getNextJokeIdx';
-
-const UPPER_BOUND = 4;
 
 const addNextJoke = async (nextJokeIdx) => {
   const nextJoke = await jokeFetcher(nextJokeIdx);
@@ -11,9 +9,10 @@ const addNextJoke = async (nextJokeIdx) => {
   renderJoke(nextJoke);
 };
 
-const bindEventListenerToRefreshButton = (currentJokeIdx) => {
+const bindEventListenerToRefreshButton = async (currentJokeIdx) => {
   const refreshButton = document.getElementById('refresh');
   let currentJokeState = currentJokeIdx;
+  const UPPER_BOUND = await jokeFetcherUpperBounds();
 
   refreshButton.addEventListener('click', async (e) => {
     e.preventDefault();

--- a/src/js/jokeFetcher.js
+++ b/src/js/jokeFetcher.js
@@ -1,3 +1,13 @@
+export const jokeFetcherUpperBounds = async () => {
+  try {
+    const result = await fetch('http://localhost:8081/jokesUpperBound');
+    const limit = await result.json();
+    return limit;
+  } catch (err) {
+    return 0;
+  }
+};
+
 export const jokeFetcher = async (jokeIdx) => {
   try {
     const result = await fetch(`http://localhost:8081/jokes/${jokeIdx}`);

--- a/src/js/jokeFetcher.spec.js
+++ b/src/js/jokeFetcher.spec.js
@@ -1,21 +1,21 @@
-import { jokeFetcher } from './jokeFetcher';
+import { jokeFetcher, jokeFetcherUpperBounds } from './jokeFetcher';
 
 const defaultFetchReference = global.fetch;
 
-beforeEach(() => {
-  global.fetch = jest.fn(() => Promise.resolve({
-    json: () => Promise.resolve({
-      setup: 'Why did the chicken cross the playground?',
-      punchline: 'To get to the other slide.',
-    }),
-  }));
-});
-
-afterEach(() => {
-  global.fetch = defaultFetchReference;
-});
-
 describe('jokeFetcher', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => Promise.resolve({
+      json: () => Promise.resolve({
+        setup: 'Why did the chicken cross the playground?',
+        punchline: 'To get to the other slide.',
+      }),
+    }));
+  });
+
+  afterEach(() => {
+    global.fetch = defaultFetchReference;
+  });
+
   it('fetches joke', async () => {
     const joke = await jokeFetcher(0);
     expect(joke).toEqual({
@@ -26,7 +26,6 @@ describe('jokeFetcher', () => {
 
   it('makes a call to the correct API endpoint', async () => {
     await jokeFetcher(3);
-
     expect(fetch).toHaveBeenCalledWith('http://localhost:8081/jokes/3');
   });
 
@@ -37,5 +36,28 @@ describe('jokeFetcher', () => {
       setup: 'Sorry, we were unable to retrieve a joke',
       punchline: 'Sadly this is not a joke',
     });
+  });
+});
+
+describe('jokeFetcherUpperBounds', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => Promise.resolve({
+      json: () => Promise.resolve(29),
+    }));
+  });
+
+  afterEach(() => {
+    global.fetch = defaultFetchReference;
+  });
+
+  it('returns a number', async () => {
+    const UPPER_BOUND = await jokeFetcherUpperBounds();
+    expect(UPPER_BOUND).toEqual(29);
+  });
+
+  it('returns a fallback number on failure', async () => {
+    fetch.mockImplementationOnce(() => Promise.reject(new Error('Some Failure')));
+    const UPPER_BOUND = await jokeFetcherUpperBounds();
+    expect(UPPER_BOUND).toEqual(0);
   });
 });


### PR DESCRIPTION
## Description
Add support for setting upper limit of joke count from API endpoint

## Spec

See Issue: [FSA22V1-78](https://sparkbox.atlassian.net/browse/FSA22V1-78)

## Validation

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Run locally and compare browser behavior to expected behavior 