### PR TITLE
refactor: Extract functions from index.js

### DIFF
--- a/src/js/addNextJoke.js
+++ b/src/js/addNextJoke.js
@@ -1,0 +1,8 @@
+import { jokeFetcher } from './jokeFetcher';
+import { renderJoke } from './renderJoke';
+
+export const addNextJoke = async (nextJokeIdx) => {
+  const nextJoke = await jokeFetcher(nextJokeIdx);
+
+  renderJoke(nextJoke);
+};

--- a/src/js/addNextJoke.spec.js
+++ b/src/js/addNextJoke.spec.js
@@ -1,0 +1,27 @@
+import { addNextJoke } from './addNextJoke';
+import { jokeFetcher } from './jokeFetcher';
+import { renderJoke } from './renderJoke';
+
+jest.mock('./jokeFetcher', () => ({
+  ...jest.requireActual('./jokeFetcher'),
+  jokeFetcher: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('./renderJoke', () => ({
+  ...jest.requireActual('./renderJoke'),
+  renderJoke: jest.fn(),
+}));
+
+describe('addNextJoke', () => {
+  it('calls jokeFetcher with next joke index', () => {
+    addNextJoke(1);
+
+    expect(jokeFetcher).toHaveBeenCalledWith(1);
+  });
+
+  it('calls addNextJoke with the updated joke index', () => {
+    addNextJoke(1);
+
+    expect(renderJoke).toHaveBeenCalled();
+  });
+});

--- a/src/js/bindEventListenerToRefreshButton.js
+++ b/src/js/bindEventListenerToRefreshButton.js
@@ -1,0 +1,13 @@
+import { getNextJokeIdx } from './getNextJokeIdx';
+import { addNextJoke } from './addNextJoke';
+
+export const bindEventListenerToRefreshButton = (currentJokeIdx = 0) => {
+  const refreshButton = document.getElementById('refresh');
+  let currentJokeState = currentJokeIdx;
+
+  refreshButton.addEventListener('click', async (e) => {
+    e.preventDefault();
+    currentJokeState = await getNextJokeIdx(currentJokeState);
+    addNextJoke(currentJokeState);
+  });
+};

--- a/src/js/bindEventListenerToRefreshButton.spec.js
+++ b/src/js/bindEventListenerToRefreshButton.spec.js
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom';
+import { bindEventListenerToRefreshButton } from './bindEventListenerToRefreshButton';
+import { getNextJokeIdx } from './getNextJokeIdx';
+import { addNextJoke } from './addNextJoke';
+
+jest.mock('./getNextJokeIdx', () => ({
+  ...jest.requireActual('./getNextJokeIdx'),
+  getNextJokeIdx: jest.fn(),
+}));
+
+jest.mock('./addNextJoke', () => ({
+  ...jest.requireActual('./addNextJoke'),
+  addNextJoke: jest.fn().mockResolvedValue(),
+}));
+
+describe('bindEventListenerToRefreshButton', () => {
+  let refreshButton;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+    <button id="refresh">Refresh</button>
+    `;
+  });
+
+  it('calls getNextJokeIdx with the current joke index', () => {
+    bindEventListenerToRefreshButton(1);
+    refreshButton = document.getElementById('refresh');
+
+    refreshButton.click();
+
+    expect(getNextJokeIdx).toHaveBeenCalledWith(1);
+  });
+
+  it('calls addNextJoke with the updated joke index', () => {
+    bindEventListenerToRefreshButton(1);
+    refreshButton = document.getElementById('refresh');
+
+    refreshButton.click();
+
+    expect(addNextJoke).toHaveBeenCalled();
+  });
+});

--- a/src/js/getNextJokeIdx.js
+++ b/src/js/getNextJokeIdx.js
@@ -1,4 +1,7 @@
-export const getNextJokeIdx = (currentJokeIdx, upperBound) => {
+import { jokeFetcherUpperBounds } from './jokeFetcher';
+
+export const getNextJokeIdx = async (currentJokeIdx) => {
+  const upperBound = await jokeFetcherUpperBounds();
   let nextJokeIdx = currentJokeIdx + 1;
 
   if (nextJokeIdx > upperBound) nextJokeIdx = 0;

--- a/src/js/getNextJokeIdx.spec.js
+++ b/src/js/getNextJokeIdx.spec.js
@@ -1,14 +1,21 @@
 import { getNextJokeIdx } from './getNextJokeIdx';
+import { jokeFetcherUpperBounds } from './jokeFetcher';
+
+jest.mock('./jokeFetcher', () => ({
+  ...jest.requireActual('./jokeFetcher'),
+  jokeFetcherUpperBounds: jest.fn().mockReturnValue(29),
+}));
 
 describe('getNextJokeIdx', () => {
-  it('incremements the current joke idx by 1', () => {
-    const nextJokeIdx = getNextJokeIdx(2);
+  it('incremements the current joke idx by 1', async () => {
+    const nextJokeIdx = await getNextJokeIdx(2);
 
     expect(nextJokeIdx).toBe(3);
   });
 
-  it('resets current joke idx to 0 when upper bound is reached', () => {
-    const nextJokeIdx = getNextJokeIdx(4, 4);
+  it('resets current joke idx to 0 when upper bound is reached', async () => {
+    const upperBounds = await jokeFetcherUpperBounds();
+    const nextJokeIdx = await getNextJokeIdx(upperBounds);
 
     expect(nextJokeIdx).toBe(0);
   });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,32 +1,13 @@
 import '../css/index.css';
-import { jokeFetcher, jokeFetcherUpperBounds } from './jokeFetcher';
+import { jokeFetcher } from './jokeFetcher';
 import { renderJoke } from './renderJoke';
-import { getNextJokeIdx } from './getNextJokeIdx';
+import { bindEventListenerToRefreshButton } from './bindEventListenerToRefreshButton';
 
-const addNextJoke = async (nextJokeIdx) => {
-  const nextJoke = await jokeFetcher(nextJokeIdx);
+const showInitialJoke = async () => {
+  const initialJoke = await jokeFetcher();
 
-  renderJoke(nextJoke);
+  renderJoke(initialJoke);
+  bindEventListenerToRefreshButton();
 };
 
-const bindEventListenerToRefreshButton = async (currentJokeIdx) => {
-  const refreshButton = document.getElementById('refresh');
-  let currentJokeState = currentJokeIdx;
-  const UPPER_BOUND = await jokeFetcherUpperBounds();
-
-  refreshButton.addEventListener('click', async (e) => {
-    e.preventDefault();
-    currentJokeState = getNextJokeIdx(currentJokeState, UPPER_BOUND);
-    addNextJoke(currentJokeState);
-  });
-};
-
-const showCurrentJoke = async () => {
-  const currentJokeIdx = 0;
-  const currentJoke = await jokeFetcher(currentJokeIdx);
-
-  renderJoke(currentJoke);
-  bindEventListenerToRefreshButton(currentJokeIdx);
-};
-
-showCurrentJoke();
+showInitialJoke();

--- a/src/js/jokeFetcher.js
+++ b/src/js/jokeFetcher.js
@@ -8,7 +8,7 @@ export const jokeFetcherUpperBounds = async () => {
   }
 };
 
-export const jokeFetcher = async (jokeIdx) => {
+export const jokeFetcher = async (jokeIdx = 0) => {
   try {
     const result = await fetch(`http://localhost:8081/jokes/${jokeIdx}`);
     const joke = await result.json();


### PR DESCRIPTION
## Description
- Following functions now living in own file and have corresponding tests:
  - `addNextJoke`
  - `bindEventListenerToRefreshButton`
  - - static constant UPPER_BOUND now scoped within `getNextJokeIdx`
- `showCurrentJoke` renamed to `showInitialJoke` for clarity

## Spec

See Issue: [FSA22V1-82](https://sparkbox.atlassian.net/browse/FSA22V1-82)

## Validation
- [x] This PR has code changes, and our linters still pass.
- [x] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Install all dependencies with `npm i`.
4. Start the API server with `nm run api`.
5. Start the app with `npm run dev`
6. Verify app behaves as expected.
7. Verify all tests pass.
