### PR TITLE
Feat  change initial joke index

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
-  collectCoverage: false,
+  collectCoverage: true,
   collectCoverageFrom: [
-    '<rootDir>/src//*.js',
+    '<rootDir>/src/**/*.js',
   ],
   moduleFileExtensions: ['js'],
   moduleNameMapper: {

--- a/src/js/bindEventListenerToRefreshButton.js
+++ b/src/js/bindEventListenerToRefreshButton.js
@@ -1,7 +1,7 @@
 import { getNextJokeIdx } from './getNextJokeIdx';
 import { addNextJoke } from './addNextJoke';
 
-export const bindEventListenerToRefreshButton = (currentJokeIdx = 0) => {
+export const bindEventListenerToRefreshButton = (currentJokeIdx) => {
   const refreshButton = document.getElementById('refresh');
   let currentJokeState = currentJokeIdx;
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,13 +1,17 @@
 import '../css/index.css';
 import { jokeFetcher } from './jokeFetcher';
+import { jokeFetcherUpperBounds } from './jokeFetcher';
 import { renderJoke } from './renderJoke';
 import { bindEventListenerToRefreshButton } from './bindEventListenerToRefreshButton';
 
 const showInitialJoke = async () => {
-  const initialJoke = await jokeFetcher();
+  const upperBounds = await jokeFetcherUpperBounds();
+  const initialJoke = await jokeFetcher(
+    Math.floor(Math.random() * upperBounds + 1)
+  );
 
   renderJoke(initialJoke);
-  bindEventListenerToRefreshButton();
+  bindEventListenerToRefreshButton(0);
 };
 
 showInitialJoke();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,12 +6,13 @@ import { bindEventListenerToRefreshButton } from './bindEventListenerToRefreshBu
 
 const showInitialJoke = async () => {
   const upperBounds = await jokeFetcherUpperBounds();
-  const initialJoke = await jokeFetcher(
-    Math.floor(Math.random() * upperBounds + 1)
-  );
+
+  const jokeIndex = Math.floor(Math.random() * upperBounds + 1);
+
+  const initialJoke = await jokeFetcher(jokeIndex);
 
   renderJoke(initialJoke);
-  bindEventListenerToRefreshButton(0);
+  bindEventListenerToRefreshButton(jokeIndex);
 };
 
 showInitialJoke();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,5 @@
 import '../css/index.css';
-import { jokeFetcher } from './jokeFetcher';
-import { jokeFetcherUpperBounds } from './jokeFetcher';
+import { jokeFetcher, jokeFetcherUpperBounds } from './jokeFetcher';
 import { renderJoke } from './renderJoke';
 import { bindEventListenerToRefreshButton } from './bindEventListenerToRefreshButton';
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,7 +3,7 @@ import { jokeFetcher, jokeFetcherUpperBounds } from './jokeFetcher';
 import { renderJoke } from './renderJoke';
 import { bindEventListenerToRefreshButton } from './bindEventListenerToRefreshButton';
 
-const showInitialJoke = async () => {
+export const showInitialJoke = async () => {
   const upperBounds = await jokeFetcherUpperBounds();
 
   const jokeIndex = Math.floor(Math.random() * upperBounds + 1);

--- a/src/js/index.spec.js
+++ b/src/js/index.spec.js
@@ -4,6 +4,7 @@ import { showInitialJoke } from './index.js';
 import { bindEventListenerToRefreshButton } from './bindEventListenerToRefreshButton';
 import { jokeFetcher, jokeFetcherUpperBounds } from './jokeFetcher';
 
+
 jest.mock('./renderJoke', () => ({
   ...jest.requireActual('./renderJoke'),
   renderJoke: jest.fn(),
@@ -20,28 +21,28 @@ jest.mock('./jokeFetcher', () => ({
   jokeFetcherUpperBounds: jest.fn(),
 }));
 
-describe('showInitialJoke', () => {
+
+describe('showInitialJoke', () => { 
   it('calls jokeFetcherUpperBounds', () => {
+    jest.clearAllMocks();
+    
     showInitialJoke();
-
-    expect(jokeFetcherUpperBounds).toHaveBeenCalled();
+    
+    expect(jokeFetcherUpperBounds).toHaveBeenCalledTimes(1);
   });
-
+  
   it('calls jokeFetcher', () => {
-    showInitialJoke();
 
-    expect(jokeFetcher).toHaveBeenCalled();
+    expect(jokeFetcher).toHaveBeenCalledTimes(1);
   });
 
   it('calls renderJoke', () => {
-    showInitialJoke();
 
-    expect(renderJoke).toHaveBeenCalled();
+    expect(renderJoke).toHaveBeenCalledTimes(1);
   });
 
   it('calls bindEventListenerToRefreshButton', () => {
-    showInitialJoke();
 
-    expect(bindEventListenerToRefreshButton).toHaveBeenCalled();
+    expect(bindEventListenerToRefreshButton).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/js/index.spec.js
+++ b/src/js/index.spec.js
@@ -16,12 +16,11 @@ jest.mock('./bindEventListenerToRefreshButton', () => ({
 
 jest.mock('./jokeFetcher', () => ({
   ...jest.requireActual('./jokeFetcher'),
- jokeFetcher: jest.fn(),
- jokeFetcherUpperBounds: jest.fn(),
+  jokeFetcher: jest.fn(),
+  jokeFetcherUpperBounds: jest.fn(),
 }));
 
 describe('showInitialJoke', () => {
-
   it('calls jokeFetcherUpperBounds', () => {
     showInitialJoke();
 
@@ -41,7 +40,6 @@ describe('showInitialJoke', () => {
   });
 
   it('calls bindEventListenerToRefreshButton', () => {
-
     showInitialJoke();
 
     expect(bindEventListenerToRefreshButton).toHaveBeenCalled();

--- a/src/js/index.spec.js
+++ b/src/js/index.spec.js
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom';
+import { renderJoke } from './renderJoke';
+import { showInitialJoke } from './index.js';
+import { bindEventListenerToRefreshButton } from './bindEventListenerToRefreshButton';
+import { jokeFetcher, jokeFetcherUpperBounds } from './jokeFetcher';
+
+jest.mock('./renderJoke', () => ({
+  ...jest.requireActual('./renderJoke'),
+  renderJoke: jest.fn(),
+}));
+
+jest.mock('./bindEventListenerToRefreshButton', () => ({
+  ...jest.requireActual('./bindEventListenerToRefreshButton'),
+  bindEventListenerToRefreshButton: jest.fn(),
+}));
+
+jest.mock('./jokeFetcher', () => ({
+  ...jest.requireActual('./jokeFetcher'),
+ jokeFetcher: jest.fn(),
+ jokeFetcherUpperBounds: jest.fn(),
+}));
+
+describe('showInitialJoke', () => {
+
+  it('calls jokeFetcherUpperBounds', () => {
+    showInitialJoke();
+
+    expect(jokeFetcherUpperBounds).toHaveBeenCalled();
+  });
+
+  it('calls jokeFetcher', () => {
+    showInitialJoke();
+
+    expect(jokeFetcher).toHaveBeenCalled();
+  });
+
+  it('calls renderJoke', () => {
+    showInitialJoke();
+
+    expect(renderJoke).toHaveBeenCalled();
+  });
+
+  it('calls bindEventListenerToRefreshButton', () => {
+
+    showInitialJoke();
+
+    expect(bindEventListenerToRefreshButton).toHaveBeenCalled();
+  });
+});

--- a/src/js/index.spec.js
+++ b/src/js/index.spec.js
@@ -4,7 +4,6 @@ import { showInitialJoke } from './index.js';
 import { bindEventListenerToRefreshButton } from './bindEventListenerToRefreshButton';
 import { jokeFetcher, jokeFetcherUpperBounds } from './jokeFetcher';
 
-
 jest.mock('./renderJoke', () => ({
   ...jest.requireActual('./renderJoke'),
   renderJoke: jest.fn(),
@@ -21,28 +20,19 @@ jest.mock('./jokeFetcher', () => ({
   jokeFetcherUpperBounds: jest.fn(),
 }));
 
-
-describe('showInitialJoke', () => { 
+describe('showInitialJoke', () => {
   it('calls jokeFetcherUpperBounds', () => {
     jest.clearAllMocks();
-    
     showInitialJoke();
-    
     expect(jokeFetcherUpperBounds).toHaveBeenCalledTimes(1);
   });
-  
   it('calls jokeFetcher', () => {
-
     expect(jokeFetcher).toHaveBeenCalledTimes(1);
   });
-
   it('calls renderJoke', () => {
-
     expect(renderJoke).toHaveBeenCalledTimes(1);
   });
-
   it('calls bindEventListenerToRefreshButton', () => {
-
     expect(bindEventListenerToRefreshButton).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/js/jokeFetcher.js
+++ b/src/js/jokeFetcher.js
@@ -8,7 +8,7 @@ export const jokeFetcherUpperBounds = async () => {
   }
 };
 
-export const jokeFetcher = async (jokeIdx = 0) => {
+export const jokeFetcher = async (jokeIdx) => {
   try {
     const result = await fetch(`http://localhost:8081/jokes/${jokeIdx}`);
     const joke = await result.json();


### PR DESCRIPTION
## Description
Add support for changing the initial load joke index

## Spec
See Issue: FSA22V1-79 [(https://sparkbox.atlassian.net/jira/software/c/projects/FSA22V1/boards/119?modal=detail&selectedIssue=FSA22V1-79)]

## Validation
- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate
1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Spin up 2 separate servers in terminal using `npm run dev` and npm run `api`
4. Navigate to localhost:8080
5. Verify that as you refresh the page, a different joke is rendered each time
6. Use the refresh button to verify that each refresh is also unique to the originally rendered joke
7. Run `npm run lint` to verify it passes all linters
8. Bonus: Run `npm run test -- --coverage` to see the now fixed and functioning coverage file

https://media.giphy.com/media/VG66xoegY8hbi/giphy.gif
